### PR TITLE
Remove unnecessary files from published package

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
   "scripts": {
     "test": "jest --coverage",
     "tdd": "jest --watch",
-    "build": "npm run test && webpack"
+    "build": "npm run test && webpack",
+    "prepare": "npm run build",
+    "prepublishOnly": "npm run build"
   },
   "author": "Stewart Anderson",
   "license": "GPL-3.0",
@@ -31,5 +33,8 @@
   },
   "dependencies": {
     "babel-runtime": "^6.26.0"
-  }
+  },
+  "files": [
+    "build"
+  ]
 }


### PR DESCRIPTION
🐞 Limit the entries included in the package using the files field
🔩 Run the build script before publishing (prepublishOnly) and before installing (prepare)

The updated package only contains: 
- LICENSE
- README
- package.json
- build/index.js

Before it also included:
- .git
- .babelrc
- webpack.config.js
- coverage
- test
- ...

Use [`npm pack`](https://docs.npmjs.com/cli/pack) to verify.

Fixes #3 